### PR TITLE
Add automatic builds and SplatTag as a submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,7 @@ jobs:
       if: github.event_name == 'push'
       # add ?restart=true to the url to automatically restart the bot
       run: |
-        curl -i \
+        curl -i --fail-with-body \
         -H "Authorization: ${{ secrets.HOSTINGTOKEN }}" \
         -F update=@Release.tar.gz \
-        https://hosting.fumple.pl/api/sv1/update || \
-        { echo "::error::Failed to upload to hosting.fumple.pl!" && exit 1; }
+        https://hosting.fumple.pl/api/sv1/update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build and test project
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    
+    - name: Restore dependencies
+      working-directory: ./src/Mavis
+      run: dotnet restore
+    - name: Build
+      working-directory: ./src/Mavis
+      run: dotnet build --no-restore --configuration Release
+    - name: Test
+      working-directory: ./src/Mavis
+      run: dotnet test --no-build --verbosity normal --configuration Release
+    
+    - name: Pack release
+      working-directory: ./src/Mavis/Mavis/bin/Release/net5.0
+      run: tar -czf ../Release.tar.gz .
+    
+    - uses: actions/upload-artifact@v3
+      name: Upload artifact
+      with:
+        path: src/Mavis/Mavis/bin/Release/Release.tar.gz
+        name: Release.tar.gz
+    
+    - name: Upload to hosting
+      working-directory: ./src/Mavis/Mavis/bin/Release
+      # only run on push, don't want a pull request slipping into the server
+      if: github.event_name == 'push'
+      # add ?restart=true to the url to automatically restart the bot
+      run: |
+        curl -i \
+        -H "Authorization: ${{ secrets.HOSTINGTOKEN }}" \
+        -F update=@Release.tar.gz \
+        https://hosting.fumple.pl/api/sv1/update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,5 @@ jobs:
         curl -i \
         -H "Authorization: ${{ secrets.HOSTINGTOKEN }}" \
         -F update=@Release.tar.gz \
-        https://hosting.fumple.pl/api/sv1/update || { echo "::error::Failed to upload to hosting.fumple.pl!" && exit 1 }
+        https://hosting.fumple.pl/api/sv1/update || \
+        { echo "::error::Failed to upload to hosting.fumple.pl!" && exit 1; }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,4 @@ jobs:
         curl -i \
         -H "Authorization: ${{ secrets.HOSTINGTOKEN }}" \
         -F update=@Release.tar.gz \
-        https://hosting.fumple.pl/api/sv1/update
+        https://hosting.fumple.pl/api/sv1/update || { echo "::error::Failed to upload to hosting.fumple.pl!" && exit 1 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SplatTag"]
+	path = SplatTag
+	url = https://github.com/kjhf/SplatTag

--- a/src/Mavis/Mavis.sln
+++ b/src/Mavis/Mavis.sln
@@ -5,9 +5,9 @@ VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mavis", "Mavis\Mavis.csproj", "{043D0C17-D502-43F9-9726-8236ABF712D0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SplatTagCore", "..\..\..\SplatTag\SplatTagCore\SplatTagCore.csproj", "{5331CDF1-FB67-4011-A79B-6F7548010A05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SplatTagCore", "..\..\SplatTag\SplatTagCore\SplatTagCore.csproj", "{5331CDF1-FB67-4011-A79B-6F7548010A05}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SplatTagDatabase", "..\..\..\SplatTag\SplatTagDatabase\SplatTagDatabase.csproj", "{5A803ECB-5F14-4ECC-A040-2DBBE652FA8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SplatTagDatabase", "..\..\SplatTag\SplatTagDatabase\SplatTagDatabase.csproj", "{5A803ECB-5F14-4ECC-A040-2DBBE652FA8A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MavisTests", "MavisTests\MavisTests.csproj", "{36A5D4BE-8115-4404-8A85-A87C76AFA08D}"
 EndProject

--- a/src/Mavis/Mavis/Mavis.csproj
+++ b/src/Mavis/Mavis/Mavis.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\SplatTag\SplatTagCore\SplatTagCore.csproj" />
-    <ProjectReference Include="..\..\..\..\SplatTag\SplatTagDatabase\SplatTagDatabase.csproj" />
+    <ProjectReference Include="..\..\..\SplatTag\SplatTagCore\SplatTagCore.csproj" />
+    <ProjectReference Include="..\..\..\SplatTag\SplatTagDatabase\SplatTagDatabase.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
TODO:
- [ ] Update README if necessary
- [x] Make it so that if auto builds fail to upload the compiled files to hosting, they leave a warning or error behind, instead of a success. (example of current behaviour: https://github.com/fumple/hMavisBot/actions/runs/4359512351/jobs/7621383296)
- [x] Add token to `Secrets -> Actions` with name `HOSTINGTOKEN`